### PR TITLE
Use <select> and <option> instead <ol> and <li> in Scaladoc examples

### DIFF
--- a/html/src/main/scala/com/yang_bo/html/package.scala
+++ b/html/src/main/scala/com/yang_bo/html/package.scala
@@ -91,12 +91,12 @@ import scala.util.chaining.given
   *
   *   val texts = Constants("foo", "bar")
   *   val node =
-  *     html"""<ol>${
-  *       for (text <- texts) yield html"<li>$text</li>".bind
-  *     }</li>"""
+  *     html"""<select>${
+  *       for (text <- texts) yield html"<option>$text</option>".bind
+  *     }</select>"""
   *   render(document.body, node)
   *   document.body.innerHTML should be(
-  *     "<ol><li>foo</li><li>bar</li></ol>"
+  *     "<select><option>foo</option><option>bar</option></select>"
   *   )
   * }}}
   */


### PR DESCRIPTION
`<ol>` and `<li>` are problematic, because Scaladoc treats `<ol>` and `<li>` as HTML, not code example.